### PR TITLE
Fix templates after more-go-like

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -199,6 +199,7 @@ func loadVendors() {
 			log.Printf("Warning: `dns_refresh_minutes` is set, but < 5 so ignoring")
 		}
 	}
+	log.Printf("Vendor config loading complete!")
 }
 
 func main() {

--- a/cmd/speedtest.go
+++ b/cmd/speedtest.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SpeedtestResults struct {
-	SpeedtestUrl string // yes, this need to be here ???
+	SpeedtestURL string // yes, this need to be here ???
 	// GlobalState values
 	Vendor       string
 	Exit         string
@@ -39,11 +39,11 @@ type SpeedtestResults struct {
 	ServerPort        float64
 	ServerIP          string
 	ResultID          string
-	ResultUrl         string
+	ResultURL         string
 }
 
 type SpeedtestRemote struct {
-	SpeedtestUrl string
+	SpeedtestURL string
 }
 
 func runSpeedtest(c echo.Context) (SpeedtestResults, error) {
@@ -91,7 +91,7 @@ func runSpeedtest(c echo.Context) (SpeedtestResults, error) {
 	}
 
 	SR := SpeedtestResults{
-		SpeedtestUrl:      "",
+		SpeedtestURL:      "",
 		Vendor:            GS.Vendor,
 		Exit:              GS.Exit,
 		ExitPath:          GS.ExitPath,
@@ -117,7 +117,7 @@ func runSpeedtest(c echo.Context) (SpeedtestResults, error) {
 		ServerPort:        server["port"].(float64),
 		ServerIP:          server["ip"].(string),
 		ResultID:          result["id"].(string),
-		ResultUrl:         result["url"].(string),
+		ResultURL:         result["url"].(string),
 	}
 
 	return SR, nil
@@ -131,7 +131,7 @@ func Speedtest(c echo.Context) error {
 			return c.Render(http.StatusOK, "error.html", "Embeded speedtest is not configured")
 		}
 		url := Konf.String("speedtest_url")
-		SR := SpeedtestRemote{SpeedtestUrl: url}
+		SR := SpeedtestRemote{SpeedtestURL: url}
 		return c.Render(http.StatusOK, "speedtest.html", SR)
 	} else if mode == "server" {
 		if !Konf.Exists("speedtest_cli") {

--- a/templates/speedtest.html
+++ b/templates/speedtest.html
@@ -1,16 +1,16 @@
 {{define "speedtest.html"}}
-{{if EmptyString .SpeedtestUrl}}
+{{if EmptyString .SpeedtestURL}}
 <ul>
-    <li>Ping latency: {{ .Ping_latency }}ms / jitter: {{ .Ping_jitter }}ms</li>
+    <li>Ping latency: {{ .PingLatency }}ms / jitter: {{ .PingJitter }}ms</li>
     <li>Packet Loss: {{ Float64ToStr .Packetloss }}%</li>
-    <li>Download: {{ BpsToMbps .Download_bandwidth }}Mbps</li>
-    <li>Upload: {{ BpsToMbps .Upload_bandwidth }}Mbps</li>
+    <li>Download: {{ BpsToMbps .DownloadBandwidth }}Mbps</li>
+    <li>Upload: {{ BpsToMbps .UploadBandwidth }}Mbps</li>
     <li>ISP: {{ .Isp }}</li>
-    <li>External IP: {{ .External_ip }}</li>
-    <li>Server ID: {{ .Server_id }}</li>
-    <li>Server Name: {{ .Server_name }}</li>
-    <li>Server Location: {{ .Server_location }}</li>
-    <li>Server Host: {{ .Server_host }}</li>
+    <li>External IP: {{ .ExternalIP }}</li>
+    <li>Server ID: {{ .ServerID }}</li>
+    <li>Server Name: {{ .ServerName }}</li>
+    <li>Server Location: {{ .ServerLocation }}</li>
+    <li>Server Host: {{ .ServerHost }}</li>
     <!--
         The Result_url contains the speedtest.net results on their website
         in a pretty manner.  I wonder if we can do something pretty with it?
@@ -23,10 +23,10 @@
 
         Can we just do a Ajax call and return that part of the dom in an iframe?
     -->
-    <li>Result on Speedtest.net: <a href="{{ .Result_url }}">Click Here</a></li>
+    <li>Result on Speedtest.net: <a href="{{ .ResultURL }}">Click Here</a></li>
 </ul>
 {{else}}
-<iframe width="100%" height="650px" frameborder="0" src="{{ .SpeedtestUrl }}"></iframe>
+<iframe width="100%" height="650px" frameborder="0" src="{{ .SpeedtestURL }}"></iframe>
 {{end}}
 {{end}}
 

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,6 +1,6 @@
 {{define "status.html"}}
 <ul>
-    <li>Status: {{ .Connected_str }}</li>
+    <li>Status: {{ .ConnectedStr }}</li>
     {{ if .Connected }}
     <li>Vendor: {{ .Vendor }}</li>
     <li>Exit Node: {{ .Exit }}</li>


### PR DESCRIPTION
- Go templates were still using many of the old struct key names
with underscores instead of StudlyCaps.
- URL is an acronym so write it as `URL` and not `Url` in variable
names